### PR TITLE
Add sleep timeout after call to rsync

### DIFF
--- a/DBGenerator_Yi.bash
+++ b/DBGenerator_Yi.bash
@@ -64,6 +64,7 @@ assembliesDownloader () {
 			link=`cat $projectName/data/index.txt | grep "$assemblyAccn" | cut -f9 | sed -s 's/ftp:/rsync:/g'`
 			echo -e "\tDownloading and decompressing $assemblyAccn..."
 			rsync -rt $link $projectName/data/assemblies/ &>> $projectName/log.txt
+   			sleep 0.34
 		else 
 			echo -e "\t$assemblyAccn already exists!"
 		fi


### PR DESCRIPTION
The rate limit for NCBI is 3 per second, so a timeout of 0.34 seconds is added after each rsync call so that we don't get our IP banned. In the future, it will also be good to change this to use the entrez toolkit, so that we can also add our email to the request, and then NCBI will email us if they have a problem with our usage of the service.